### PR TITLE
Fix: Update cover section background image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -68,8 +68,7 @@ body {
       }
 
       .cover-section {
-        background: url("https://wownepal.com.np/wp-content/uploads/2022/12/Thumbnail.jpg")
-          bottom/cover no-repeat;
+        background: url("https://placehold.co/1600x900/663399/FFFFFF?text=Music+Festival") bottom/cover no-repeat;
         color: #ffffff;
         margin: 15px;
         border-radius: 8px;


### PR DESCRIPTION
Replaced the broken background image URL in the .cover-section with a functional placeholder image from placehold.co. This ensures the section displays a background image as intended. The previous URL was no longer accessible.